### PR TITLE
feat: add mod_oauth2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 VEXXHOST, Inc.
+# SPDX-FileCopyrightText: © 2026 VEXXHOST, Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:ab36427f87c8f9cca8ce2ed1726b927f2026acdebb5f2a52350c71bb0659882b AS build
@@ -23,9 +23,13 @@ apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
 ARG MOD_AUTH_OPENIDC_VERSION=2.4.18.1
+# NOTE: Always use compatible version of liboauth2 and mod_oauth2,
+#       otherwise mod_oauth2 will fail to load due to missing shared library.
+ARG LIBOAUTH2_VERSION=2.1.1
+ARG MOD_OAUTH2_VERSION=4.1.0
 ARG TARGETARCH
 RUN <<EOF bash -xe
-# TODO(mnaser): mod_auth_openidc does not have aarch64 builds
+# TODO(mnaser): mod_auth_openidc and mod_oauth2 does not have aarch64 builds
 if [ "${TARGETARCH}" = "arm64" ]; then
     exit 0
 fi
@@ -34,10 +38,21 @@ apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
     curl
 curl -LO https://github.com/OpenIDC/mod_auth_openidc/releases/download/v${MOD_AUTH_OPENIDC_VERSION}/libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
-apt-get install -y --no-install-recommends ./libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
-a2enmod auth_openidc
+curl -LO https://github.com/OpenIDC/liboauth2/releases/download/v${LIBOAUTH2_VERSION}/liboauth2_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
+curl -LO https://github.com/OpenIDC/liboauth2/releases/download/v${LIBOAUTH2_VERSION}/liboauth2-apache_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
+curl -LO https://github.com/OpenIDC/mod_oauth2/releases/download/v${MOD_OAUTH2_VERSION}/libapache2-mod-oauth2_${MOD_OAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
+apt-get install -y --no-install-recommends \
+    ./libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    ./liboauth2_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    ./liboauth2-apache_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    ./libapache2-mod-oauth2_${MOD_OAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
+a2enmod auth_openidc oauth2
 apt-get purge -y --auto-remove curl
 apt-get clean
-rm -rfv /var/lib/apt/lists/* libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
+rm -rfv /var/lib/apt/lists/* \
+    libapache2-mod-auth-openidc_${MOD_AUTH_OPENIDC_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    liboauth2_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    liboauth2-apache_${LIBOAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb \
+    libapache2-mod-oauth2_${MOD_OAUTH2_VERSION}-1.$(lsb_release -sc)_${TARGETARCH}.deb
 EOF
 COPY --from=build --link /var/lib/openstack /var/lib/openstack


### PR DESCRIPTION
Add mod_oauth2. This allows JWKS verification per domain/realm.

In Atmosphere for Keystone we are using this configuration snippet:
```
{% for domain in keystone_domains %}
<Location /v3/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/auth>
  AuthType oauth20  
  Require valid-user
</Location>
...
{% endfor %}
```

After mod_oauth2 introduction we can change to:

```
{% for domain in keystone_domains %}
<Location /v3/OS-FEDERATION/identity_providers/{{ domain.name }}/protocols/openid/auth>
  AuthType oauth2
  Require valid-user
  OAuth2TargetPass prefix=OIDC-
  OAuth2TokenVerify jwks_uri {{ domain.keycloak_server_url }}/realms/{{ domain.keycloak_realm }}/protocol/openid-connect/certs
</Location>
...
{% endfor %}
```
This adds more options for token verification using JWKS uri, token introspection or jwt token attribute check PER domain.

Inspiration for this change is https://github.com/vexxhost/sunrise/pull/39 for Sunrise where same JWT token from Keycloak used for Keystone auth used once again over token exchange to authorize user to access S3 resources.

